### PR TITLE
Allow matching whole file paths

### DIFF
--- a/src/main/java/brq/intellij/plugins/commit/checklist/checkin/CommitChecklistHandler.java
+++ b/src/main/java/brq/intellij/plugins/commit/checklist/checkin/CommitChecklistHandler.java
@@ -89,7 +89,7 @@ public class CommitChecklistHandler extends CheckinHandler {
     private boolean isFileMatchingFileMask(Collection<File> files, String fileMask) {
         try {
             Condition<CharSequence> fileMaskCondition = FindInProjectUtil.createFileMaskCondition(fileMask);
-            return files.stream().anyMatch(f -> fileMaskCondition.value(f.getName()));
+            return files.stream().anyMatch(f -> fileMaskCondition.value(f.getPath()));
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/brq/intellij/plugins/commit/checklist/settings/ui/SettingsTable.java
+++ b/src/main/java/brq/intellij/plugins/commit/checklist/settings/ui/SettingsTable.java
@@ -53,7 +53,7 @@ public class SettingsTable extends TableModelEditor<MessageItem> {
     public static ColumnInfo[] getColumns() {
         return new ColumnInfo[] {
                 new EditableColumn("Item", VALUE),
-                new EditableColumn("File mask", FILE_MASK)
+                new EditableColumn("File path mask", FILE_MASK)
         };
     }
 


### PR DESCRIPTION
Hi,
Awesome plugin, especially for scatterbrains like me! 
This PR adds feature of allowing whole path matching (i.e. whether a file from /database/migrations/*.php was changed)

I've build it myself and had it working without a problem.